### PR TITLE
Add `labels` field to EntityRegistryEntry

### DIFF
--- a/homeassistant_api/models/entity_registry.py
+++ b/homeassistant_api/models/entity_registry.py
@@ -51,6 +51,7 @@ class EntityRegistryEntry(BaseModel):
     hidden_by: EntityHiddenBy | None = None
     icon: str | None = None
     id: str
+    labels: set[str] = Field(default_factory=set)
     modified_at: DatetimeIsoField
     name: str | None = None
     options: dict[str, Any] = Field(default_factory=dict)


### PR DESCRIPTION
This one-line PR allows to read the entity labels via the entity registry.

See https://github.com/home-assistant/core/blob/902159387848e70ff93a0b99a09e3768c21bb1d3/homeassistant/helpers/entity_registry.py#L219 for the HomeAssistant model, which contains `labels: set[str]`.

I did not need to update the tests, as the model creation is covered by test_entity_registry.py / `test_list_entity_registry`. The recorded cassettes contain the labels field in the HA response.

