### PR TITLE
Fix CI: bump ruff/zuban, remove dead code, drop leaked codecov token

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,9 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     hooks:
       - id: trailing-whitespace
-    rev: "v4.1.0"
+    rev: "v6.0.0"
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.6'
+    rev: 'v0.16.5'
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@
 from homeassistant_api import Client
 
 with Client(
-    '<API Server URL>', # i.e. 'http://homeassistant.local:8123/api/'
-    '<Your Long Lived Access-Token>'
+    "<API Server URL>",  # i.e. 'http://homeassistant.local:8123/api/'
+    "<Your Long Lived Access-Token>",
 ) as client:
-    client.trigger_service('light', 'turn_on', entity_id="light.living_room")
+    client.trigger_service("light", "turn_on", entity_id="light.living_room")
 ```
 
 All four client classes share the same method names.
@@ -35,12 +35,14 @@ The async clients (`AsyncClient`, `AsyncWebsocketClient`) use `async def` method
 import asyncio
 from homeassistant_api import AsyncClient
 
+
 async def main():
     async with AsyncClient(
-        '<REST API Server URL>', # i.e. 'http://homeassistant.local:8123/api/'
-        '<Your Long Lived Access-Token>',
+        "<REST API Server URL>",  # i.e. 'http://homeassistant.local:8123/api/'
+        "<Your Long Lived Access-Token>",
     ) as client:
-        await client.trigger_service('light', 'turn_on', entity_id="light.living_room")
+        await client.trigger_service("light", "turn_on", entity_id="light.living_room")
+
 
 asyncio.run(main())
 ```
@@ -51,10 +53,10 @@ asyncio.run(main())
 from homeassistant_api import WebsocketClient
 
 with WebsocketClient(
-    '<WS API Server URL>', # i.e. 'ws://homeassistant.local:8123/api/websocket'
-    '<Your Long Lived Access-Token>'
+    "<WS API Server URL>",  # i.e. 'ws://homeassistant.local:8123/api/websocket'
+    "<Your Long Lived Access-Token>",
 ) as ws_client:
-    ws_client.trigger_service('light', 'turn_on', entity_id="light.living_room")
+    ws_client.trigger_service("light", "turn_on", entity_id="light.living_room")
 ```
 
 ## Documentation

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,1 @@
-codecov: 
- token: 2f0c3d11-6099-4276-a5f0-1ad68499ad26
+codecov: {}

--- a/homeassistant_api/processing.py
+++ b/homeassistant_api/processing.py
@@ -117,9 +117,7 @@ _PARSERS: dict[str, Callable[[ResponseType], Any]] = {
 def _parse_content(response: ResponseType) -> Any:
     """Look up and call the appropriate parser by content-type."""
     content_type = response.headers.get("content-type", "text/plain")
-    if isinstance(content_type, bytes):
-        content_type = content_type.decode("utf-8")  # pragma: no cover
-    mimetype = str(content_type).split(";")[0].strip().lower()
+    mimetype = content_type.split(";")[0].strip().lower()
 
     if (parser := _PARSERS.get(mimetype)) is None:
         msg = f"No response processor found for mimetype {mimetype!r}."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ ignore = [
     "FBT",
     "TD",
     "FIX",
+    "CPY",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["hatchling"]
 
 [project]
 name = "HomeAssistant-API"
-version = "6.0.1"
+version = "6.1.0"
 description = "Python Wrapper for Homeassistant's REST API"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -499,6 +499,7 @@ def test_trigger_service(cached_client: Client) -> None:
     logger.info(resp)
     assert isinstance(resp, tuple)
 
+
 def test_call_service(cached_client: Client) -> None:
     """Tests the `POST /api/services/<domain>/<service>` endpoint."""
     notify = cached_client.get_domain("notify")


### PR DESCRIPTION
## Summary
- Ruff 0.16 promoted CPY001 (copyright notice) to stable under our `select=ALL` config, breaking CI on every file; added `CPY` to ignore
- Bumped pre-commit hook revs (ruff v0.15.6→v0.16.5, pre-commit-hooks v4.1.0→v6.0.0) to match
- Removed a bytes-decode branch in `processing.py` — static analysis confirms it's unreachable given niquests' typed `headers.get()` return
- Dropped the plaintext codecov upload token from `codecov.yml` (public repo, tokenless upload works; CI itself uses `secrets.CODECOV_TOKEN`, untouched)
- Version bump to 6.1.0 for the `labels` field addition in #246

## Test plan
- [x] `ruff format --check`, `ruff check`, `zuban check` all pass
- [x] Full test suite passes (175 tests)
- [x] CI green on this PR